### PR TITLE
Editor doesn't load after selecting custom icon

### DIFF
--- a/src/Terratype/App_Plugins/Terratype/Scripts/terratype.js
+++ b/src/Terratype/App_Plugins/Terratype/Scripts/terratype.js
@@ -405,7 +405,7 @@
                 return root.location.protocol + '//' + root.location.hostname + (root.location.port ? ':' + root.location.port : '') + url;
             },
             iconCustom: function () {
-                $scope.config().icon.id = $scope.vm().icon.predefine[0].id;
+                $scope.config().icon.id = $scope.terratype.icon.predefine[0].id;
                 if (!$scope.vm().icon.anchor.horizontal.isManual) {
                     switch ($scope.vm().icon.anchor.horizontal.automatic) {
                         case 'left':


### PR DESCRIPTION
The editor doesn't load anymore after selecting the icon predefine `[Custom]`, because the following JS error occurs: `$scope.vm(...).icon.predefine is undefined`. I've tested this with the Google Maps V3 provider, but that shouldn't matter, since the error comes from the core library.

The predefined icons were incorrectly fetched from the view model (`$scope.vm().icon.predefine`), but should be fetched from the `$scope.terratype` property. This only occurred in the `iconCustom` function and I've fixed this in the PR.